### PR TITLE
split module has changed default behavior {trailing: false}

### DIFF
--- a/test/end.js
+++ b/test/end.js
@@ -24,6 +24,6 @@ test('join a split stream', function (t) {
         .pipe(ws)
     ;
     
-    rs.emit('data', 'abc\ndef\nhi\njkl\n');
+    rs.emit('data', 'abc\ndef\nhi\njkl');
     rs.emit('end');
 });

--- a/test/join.js
+++ b/test/join.js
@@ -24,6 +24,6 @@ test('join a split stream', function (t) {
         .pipe(ws)
     ;
     
-    rs.emit('data', 'abc\ndef\nhi\njkl\n');
+    rs.emit('data', 'abc\ndef\nhi\njkl');
     rs.emit('end');
 });


### PR DESCRIPTION
The split module version 1.0.0 has changed its default behavior to {trailing: false} which means the last empty line is not ignored. It causes join-stream's test fail.

https://github.com/dominictarr/split/pull/15